### PR TITLE
solved favourite button navigation by passing event

### DIFF
--- a/src/components/Server.tsx
+++ b/src/components/Server.tsx
@@ -61,7 +61,7 @@ export class ServerRow extends ServerBase{
 export class ServerCard extends ServerBase{
   render(): JSX.Element{
     return (
-      <div onClick={() => this.onClick()}>
+      <div onClick={(e) => this.onClick(e)}>
         <h2>
           <button className="btn icon" onClick={() => {
             favoriteServer(this.props.server);


### PR DESCRIPTION
in the ServerCard components outer divs onclick was getting fired even though pressing the button. passing the event from divs onClick checks the events classList and ignores using shouldIgnoreClick() thus no push happening to history.